### PR TITLE
Increased config.txt buffer size x4

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -4,7 +4,7 @@
 #include "iup.h"
 #include "windivert.h"
 
-#define CLUMSY_VERSION "0.4 - ITH Alpha 2"
+#define CLUMSY_VERSION "0.4.1 - ITH Alpha 2"
 #define MSG_BUFSIZE 512
 #define FILTER_BUFSIZE 1024
 #define NAME_SIZE 16

--- a/src/main.c
+++ b/src/main.c
@@ -46,7 +46,7 @@ static void uiSetupModule(Module *module, Ihandle *parent);
 // serializing config files using a stupid custom format
 #define CONFIG_FILE "config.txt"
 #define CONFIG_MAX_RECORDS 64
-#define CONFIG_BUF_SIZE 4096
+#define CONFIG_BUF_SIZE 16384
 typedef struct {
     char* filterName;
     char* filterValue;


### PR DESCRIPTION
The program used to allocate only 4096 bytes to read from the config.txt file, anything else was truncated. This fix increases the buffer size to 16384 to allow for larger config files.