### PR TITLE
COMM-1182: Increase delay accuracy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 etc/clumsy.aps
 obj_vs
 obj_gmake
+premake*.exe

--- a/src/common.h
+++ b/src/common.h
@@ -4,7 +4,7 @@
 #include "iup.h"
 #include "windivert.h"
 
-#define CLUMSY_VERSION "0.4.1 - ITH Alpha 2"
+#define CLUMSY_VERSION "0.4.2 - ITH Alpha 3"
 #define MSG_BUFSIZE 512
 #define FILTER_BUFSIZE 1024
 #define NAME_SIZE 16
@@ -177,7 +177,7 @@ BOOL checkDirection(BOOL outboundPacket, short handleInbound, short handleOutbou
 
 
 // wraped timeBegin/EndPeriod to keep calling safe and end when exit
-#define TIMER_RESOLUTION 4
+#define TIMER_RESOLUTION 1
 void startTimePeriod();
 void endTimePeriod();
 

--- a/src/divert.c
+++ b/src/divert.c
@@ -8,7 +8,7 @@
 #define MAX_PACKETSIZE 0xFFFF
 #define READ_TIME_PER_STEP 3
 // FIXME does this need to be larger then the time to process the list?
-#define CLOCK_WAITMS 40
+#define CLOCK_WAITMS 1
 #define QUEUE_LEN 2 << 10
 #define QUEUE_TIME 2 << 9 
 


### PR DESCRIPTION
Make timer frequency much faster to improve delay simulation accuracy.

I tested delay, loss, and cap disturbances, and they all seem to work as well or better than before these changes.

I think CPU usage is increased slightly.